### PR TITLE
Add formatting and output rules for resumes and cover letters

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,14 @@ This approach was inspired by [Mischa van den Burg's KubeCraft](https://mischava
 - **[Farah Sharghi](https://www.farahsharghi.com/)** - Ex-Google recruiter who has reviewed 136,000+ resumes at Google, TikTok, Uber, Lyft, and The New York Times. Her YouTube channel is full of practical advice on how recruiters actually evaluate candidates. Her video [Ex-Google Recruiter Explains Why "Lying" Gets You Hired](https://www.youtube.com/watch?v=T__1QViXUxk) is a great one to watch before every interview.
 - **[Mischa van den Burg / KubeCraft](https://mischavandenburg.com/aboutme/)** - DevOps engineer who advocates for career sovereignty and self-directed learning. His approach to building skills through real projects and public documentation is worth studying.
 
+## A Note on AI-Generated Writing
+
+AI has recognizable writing patterns. Recruiters and hiring managers are increasingly aware of them. If your resume and cover letter read like they were written by a chatbot, that's not a good look.
+
+The project instructions include specific rules to avoid common AI tells: inflated language, overused transitions, uniform sentence structure, and the kind of polished-but-generic tone that screams "I didn't write this." But instructions only go so far. You still need to read every output and make sure it sounds like you, not a press release.
+
+For a detailed reference on what to watch for, see [Wikipedia: Signs of AI Writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing). It's worth reading once and keeping in mind as you review AI output. The instructions in this project already incorporate the key points, but knowing what to look for yourself makes you a better editor of your own materials.
+
 ## Files in This Repo
 
 | File | Purpose |

--- a/instructions.md
+++ b/instructions.md
@@ -74,6 +74,10 @@ Avoid: Managed, Oversaw, Collaborated, Focused on, Responsible for, Helped with
 - Use parentheticals to tie past experience to the target role when the connection isn't obvious (e.g., "Led hybrid cloud migration (relevant to enterprise SaaS infrastructure)")
 - Resumes must fit on one page. If it's running long, cut the weakest bullets rather than shrinking the font or cramming it in.
 - Cover letters must fit on one page. Four paragraphs max. If you can't make the case in one page, tighten the writing.
+- ATS friendly: avoid tables, columns, graphics, text boxes, and headers/footers. Most applicant tracking systems choke on fancy formatting. Keep it simple and parseable.
+- Contact info at the top of every resume: name, phone, email, LinkedIn. Don't make recruiters hunt for it.
+- Use a consistent date format throughout (e.g., "Jan 2020 to Mar 2023"). Pick one style and stick with it.
+- Proofread everything for typos and grammar before presenting final output. A single typo on a resume can get it tossed.
 
 ## The Connection Test
 

--- a/instructions.md
+++ b/instructions.md
@@ -72,6 +72,8 @@ Avoid: Managed, Oversaw, Collaborated, Focused on, Responsible for, Helped with
 - No filler phrases
 - Bullet points lead with metrics or scale, not tasks
 - Use parentheticals to tie past experience to the target role when the connection isn't obvious (e.g., "Led hybrid cloud migration (relevant to enterprise SaaS infrastructure)")
+- Resumes must fit on one page. If it's running long, cut the weakest bullets rather than shrinking the font or cramming it in.
+- Cover letters must fit on one page. Four paragraphs max. If you can't make the case in one page, tighten the writing.
 
 ## The Connection Test
 

--- a/instructions.md
+++ b/instructions.md
@@ -79,6 +79,20 @@ Avoid: Managed, Oversaw, Collaborated, Focused on, Responsible for, Helped with
 - Use a consistent date format throughout (e.g., "Jan 2020 to Mar 2023"). Pick one style and stick with it.
 - Proofread everything for typos and grammar before presenting final output. A single typo on a resume can get it tossed.
 
+### Don't Sound Like AI
+
+Recruiters and hiring managers can spot AI-generated writing. Avoid these common tells (ref: [Wikipedia: Signs of AI Writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing)):
+
+- No inflated symbolism: never use "stands as a testament," "plays a vital role," "watershed moment," "leaves a lasting impact," "solidifies"
+- No travel-brochure language: never use "rich cultural heritage," "breathtaking," "enduring legacy," "cultural tapestry"
+- No editorializing: never use "it's important to note," "worth considering," "no discussion would be complete without"
+- No overused transitions: limit "moreover," "furthermore," "in addition," "in contrast," "on the other hand"
+- No negative parallelism: avoid the "it's not X, it's Y" pattern
+- No superficial "-ing" conclusions: avoid "improving convenience," "ensuring safety," "highlighting importance"
+- No vague attribution: never use "industry reports suggest," "observers have cited," "some critics argue"
+- Vary sentence length and paragraph size. Uniform structure is an AI tell.
+- Write like a person, not a press release. Direct, specific, and conversational beats polished and generic every time.
+
 ## The Connection Test
 
 After writing each bullet, verify: "Would a recruiter scanning this for 6 seconds understand why it matters for this job?" If no, add a parenthetical tie-in or rewrite it.


### PR DESCRIPTION
## Summary
- One-page limit for resumes and cover letters
- ATS compatibility guidance (no tables, columns, graphics)
- Contact info placement requirement
- Consistent date format rule
- Proofreading before final output