### PR TITLE
Add ethical guardrails and CI linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,38 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  markdown-lint:
+    name: Markdown Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: "**/*.md"
+
+  link-check:
+    name: Link Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v2
+        with:
+          args: "--no-progress **/*.md"
+          fail: true
+
+  gitleaks:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,24 @@
+{
+  "config": {
+    // Allow long lines (prose doesn't wrap at 80 chars)
+    "MD013": false,
+    // Allow inline HTML (badges use img tags)
+    "MD033": false,
+    // Allow duplicate headings (templates reuse section names)
+    "MD024": false,
+    // Allow trailing punctuation in headings
+    "MD026": false,
+    // Allow multiple top-level headings (templates have their own H1)
+    "MD025": false,
+    // Allow bold text as pseudo-headings in templates
+    "MD036": false,
+    // Relaxed blank lines around lists (prose-heavy docs)
+    "MD032": false,
+    // Allow bare URLs in instructions (YouTube links etc)
+    "MD034": false,
+    // Relaxed table alignment (separator rows don't need to match)
+    "MD060": false,
+    // Allow code fences without language specifier
+    "MD040": false
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AI-Powered Job Search System
 
+[![Lint](https://github.com/8do-abehn/job-hunt-project-claude/actions/workflows/lint.yml/badge.svg)](https://github.com/8do-abehn/job-hunt-project-claude/actions/workflows/lint.yml)
+
 A structured approach to job hunting using a Claude Project (or any AI assistant) as your personal career coach. This system helps you evaluate roles, tailor resumes and cover letters, prepare for interviews, and track your search over time.
 
 Read the full blog post: [Building an AI-Powered Job Search System with Claude Projects](https://lab.8devops.com/posts/2026-02-26-ai-job-search-system/)
@@ -208,6 +210,8 @@ If you're collecting unemployment benefits, most states require you to document 
 |---|---|---|---|---|---|
 
 Copy-paste ready for whatever form your state needs. If your state requires different columns, just tell AI and it will adjust the format.
+
+Only roles you actually applied to should appear on this report. Roles that were evaluated or researched but never submitted do not count as work search activity. Unemployment fraud is a serious legal issue, so make sure the report is accurate before submitting it.
 
 ## Review Everything Before It Goes Out
 

--- a/instructions.md
+++ b/instructions.md
@@ -105,6 +105,8 @@ Concise and truthful are non-negotiable. Never inflate a number I can't defend i
 
 I will never fabricate experience or overstate a skill to manufacture fit. If the role requires something I genuinely don't have, tell me plainly rather than paper over it. A stretch is fine. A lie is not.
 
+Tailoring means highlighting real experience that is relevant to the role, not reframing unrelated work to sound like something it wasn't. Every bullet on a tailored resume should be something I can walk through in detail during an interview. If I can't explain it confidently and honestly, it doesn't belong on the page.
+
 ## Fit Assessment Rubric
 
 When I bring a job posting, evaluate it against this rubric before any tailoring:
@@ -213,7 +215,7 @@ If I am collecting unemployment benefits, I may need to document my job search a
 | Date Applied | Company Name | Company Website | Position Title | How Applied | Result |
 |---|---|---|---|---|---|
 
-Pull this data from the conversations in this project. If any fields are missing, ask me to fill in the gaps. The output should be copy-paste ready for whatever form my state requires. Adjust the columns if I tell you my state needs a different format.
+Pull this data from the conversations in this project. Only include roles I actually applied to. Never pad the report with roles that were only evaluated or researched but not submitted. Unemployment fraud is a serious legal issue, and this report must be an accurate record. If any fields are missing, ask me to fill in the gaps. The output should be copy-paste ready for whatever form my state requires. Adjust the columns if I tell you my state needs a different format.
 
 ## Urgency Awareness
 


### PR DESCRIPTION
## Summary
- Add explicit tailoring vs spinning guardrail to the honesty policy in instructions
- Add unemployment report accuracy warning (only real applications, fraud warning)
- Add GitHub Actions CI workflow: markdownlint, link checking (lychee), and secret scanning (gitleaks)
- Add lint status badge to README

## Test plan
- [ ] Verify CI workflow runs on PR and all three jobs pass
- [ ] Confirm badge renders on README after merge
- [ ] Review honesty policy and unemployment report language for clarity