### PR TITLE
Add gitleaks pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Scan staged changes for secrets before allowing commit
+if ! command -v gitleaks &>/dev/null; then
+  echo "gitleaks not installed — install with: brew install gitleaks"
+  exit 1
+fi
+
+gitleaks protect --staged --verbose


### PR DESCRIPTION
## Summary
- Adds portable pre-commit hook in `.githooks/` that runs `gitleaks protect --staged` before every commit
- Prevents secrets from being committed locally (complements the CI gitleaks scan in `lint.yml`)
- Requires one-time setup: `git config core.hooksPath .githooks`

## Test plan
- [x] Verified gitleaks scans staged changes on commit
- [ ] Clone fresh and confirm hook activates after running `git config core.hooksPath .githooks`