### PR TITLE
Add weekly issues digest via apprise

### DIFF
--- a/.github/workflows/weekly-issues-digest.yml
+++ b/.github/workflows/weekly-issues-digest.yml
@@ -1,0 +1,43 @@
+name: Weekly Issues Digest
+
+on:
+  schedule:
+    # Every Monday at 9am UTC (3am CST / 4am CDT)
+    - cron: '0 9 * * 1'
+  workflow_dispatch: # manual trigger for testing
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build digest
+        id: digest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          ISSUES=$(gh issue list --repo "$REPO" --state open --json number,title,createdAt \
+            --template '{{range .}}- #{{.number}} — {{.title}} (opened {{timeago .createdAt}})
+          {{end}}')
+
+          if [ -z "$ISSUES" ]; then
+            echo "empty=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          MSG="Weekly Issues Digest — $(date -u +%Y-%m-%d)
+
+          Open issues for $REPO:
+
+          $ISSUES"
+
+          # Save for next step
+          echo "$MSG" > /tmp/digest.txt
+
+      - name: Send notification via apprise
+        if: steps.digest.outputs.empty != 'true'
+        run: |
+          pip install -q apprise
+          apprise -t "Job Hunt: Weekly Digest" \
+            --body "$(cat /tmp/digest.txt)" \
+            "${{ secrets.APPRISE_URL }}"


### PR DESCRIPTION
## Summary
- Weekly cron workflow (Mondays 9am UTC) that lists open issues and sends a notification via apprise
- Reuses the same apprise backend as the homelab backup notifications
- Manual trigger via workflow_dispatch for testing
- Skips notification if no open issues

## Test plan
- [ ] Trigger manually via Actions > Weekly Issues Digest > Run workflow
- [ ] Verify notification arrives on the same channel as backup alerts